### PR TITLE
fix: prevent bundled config from overriding runtime config

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,17 @@
+# 环境变量
+NODE_ENV = production
+
+# 网站标题
+VUE_APP_TITLE = EZ THEME
+
+# vue 环境变量
+VUE_APP_ENV = production
+
+# 是否启用反调试功能（阻止开发者工具和F12调试）true开启/false关闭
+VUE_APP_DEBUGGING = false
+
+# 打包时是否生成 ./afwd123d.js 即站点配置文件(随机名称)，如果为false，不会生成独立配置文件
+VUE_APP_CONFIGJS = true
+
+# 打包后的 ./afwd123d.js 即站点配置文件 是否混淆, VUE_APP_CONFIGJS 为true时才生效
+VUE_APP_OBFUSCATION = false

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 ﻿import disableDevtool from "disable-devtool";
 
-const env = import.meta.env;
-const isProd = env.MODE === "production";
+const env = process.env;
+const isProd = env.NODE_ENV === "production";
 const enableConfigJS = env.VUE_APP_CONFIGJS == "true";
 const enableAntiDebugging = env.VUE_APP_DEBUGGING == "true";
 


### PR DESCRIPTION
Fix production config loading so the external runtime config remains effective after build.